### PR TITLE
Force remove Gemfile.lock

### DIFF
--- a/asserts/Docker/Dockerfile
+++ b/asserts/Docker/Dockerfile
@@ -22,4 +22,4 @@ RUN echo "deb http://repo-doc-onlyoffice-com.s3.amazonaws.com/ubuntu/trusty/only
     apt-get -y update && \
     apt-get --allow-unauthenticated -y install onlyoffice-documentcreator
 
-CMD /bin/bash -l -c "cd /doc-builder-testing; git pull; bundle install; parallel_rspec spec"
+CMD /bin/bash -l -c "cd /doc-builder-testing; git pull; rm Gemfile.lock; bundle install; parallel_rspec spec"


### PR DESCRIPTION
Without it - it holds old version of ooxml_parser gem
And not possible to fetch new version, without rebuilding docker
of onlyofficetestingrobot/doc-builder-testing