### PR TITLE
Run once onlyoffice-documentbuilder once

### DIFF
--- a/asserts/Docker/Dockerfile
+++ b/asserts/Docker/Dockerfile
@@ -11,6 +11,7 @@ RUN git clone https://github.com/ONLYOFFICE/doc-builder-testing && cd /doc-build
 RUN echo "deb http://repo-doc-onlyoffice-com.s3.amazonaws.com/ubuntu/trusty/onlyoffice-documentbuilder/origin/develop/latest/ repo/" >> /etc/apt/sources.list && \
     apt-get -y update && \
     apt-get --allow-unauthenticated -y install onlyoffice-documentbuilder
+RUN onlyoffice-documentbuilder
 
 CMD /bin/bash -l -c "apt-get install --only-upgrade onlyoffice-documentbuilder; \
                      cd /doc-builder-testing; git pull; \


### PR DESCRIPTION
First run correctly generate license file
Without it it docubuilder run in parallel several process can
run into deadlock while creating trial license