### PR TITLE
Remove merge alias from ooxml_parser

### DIFF
--- a/spec/docx/paragraph/tables/table_with_merge_spec.rb
+++ b/spec/docx/paragraph/tables/table_with_merge_spec.rb
@@ -5,8 +5,8 @@ describe 'Add table with merge' do
     docx = DocBuilderWrapper.new.build_doc_and_parse('asserts/js/docx/paragraph/tables/table_with_merge.js')
     expect(docx.elements[1].rows.length).to eq(5)
     expect(docx.elements[1].rows[1].cells[1].elements.first.character_style_array[1].text).to eq('Merged cell')
-    expect(docx.elements[1].rows[1].cells[1].properties.merge.count_of_merged_cells).to eq(2)
-    expect(docx.elements[1].rows[1].cells[1].properties.merge.type).to eq('horizontal')
-    expect(docx.elements[1].rows[1].cells[1].properties.merge.value).to eq(2)
+    expect(docx.elements[1].rows[1].cells[1].properties.grid_span.count_of_merged_cells).to eq(2)
+    expect(docx.elements[1].rows[1].cells[1].properties.grid_span.type).to eq('horizontal')
+    expect(docx.elements[1].rows[1].cells[1].properties.grid_span.value).to eq(2)
   end
 end


### PR DESCRIPTION
Since https://github.com/ONLYOFFICE/ooxml_parser/pull/194