### PR TITLE
`TableCellProperties` use `Shade` class

### DIFF
--- a/spec/docx/paragraph/tables/table_with_cell_borders_and_background_spec.rb
+++ b/spec/docx/paragraph/tables/table_with_cell_borders_and_background_spec.rb
@@ -4,7 +4,7 @@ describe 'Add table with cells with borders and background' do
   it 'Table with cell background: red' do
     docx = DocBuilderWrapper.new.build_doc_and_parse('asserts/js/docx/paragraph/tables/table_with_cell_borders.js')
     expect(docx.elements[1].rows.length).to eq(3)
-    expect(docx.elements[1].rows.first.cells[1].properties.shd).to eq(OoxmlParser::Color.new(255, 0, 0))
+    expect(docx.elements[1].rows.first.cells[1].properties.shade.fill).to eq(OoxmlParser::Color.new(255, 0, 0))
   end
 
   it 'Table with cell borders: top, left, top, bottom' do

--- a/spec/docx/smoke/api_table_cell_properties_spec.rb
+++ b/spec/docx/smoke/api_table_cell_properties_spec.rb
@@ -64,7 +64,7 @@ describe 'ApiTableCellPr section tests' do
 
   it 'ApiTableCellPr | SetShd method' do
     docx = DocBuilderWrapper.new.build_doc_and_parse('asserts/js/docx/smoke/ApiTableCellPr/setshd.js')
-    expect(docx.elements[1].properties.table_style.table_cell_properties.shd).to eq(OoxmlParser::Color.new(255, 104, 0))
+    expect(docx.elements[1].properties.table_style.table_cell_properties.shade.fill).to eq(OoxmlParser::Color.new(255, 104, 0))
   end
 
   it 'ApiTableCellPr | SetTextDirection method' do

--- a/spec/docx/smoke/api_table_spec.rb
+++ b/spec/docx/smoke/api_table_spec.rb
@@ -61,11 +61,9 @@ describe 'ApiTable section tests' do
   end
 
   it 'ApiTable | SetShd method' do
-    pending 'https://github.com/ONLYOFFICE/ooxml_parser/issues/174'
-    expect('fixed?').to eq('true')
     docx = DocBuilderWrapper.new.build_doc_and_parse('asserts/js/docx/smoke/ApiTable/setshd.js')
-    expect(docx.elements[1].properties.shd.color).to eq(OoxmlParser::Color.new(238, 238, 238))
-    expect(docx.elements[1].properties.shd.type).to eq('clear')
+    expect(docx.elements[1].properties.shade.fill).to eq(OoxmlParser::Color.new(238, 238, 238))
+    expect(docx.elements[1].properties.shade.value).to eq(:clear)
   end
 
   it 'ApiTable | SetStyle method' do


### PR DESCRIPTION
Since https://github.com/ONLYOFFICE/ooxml_parser/pull/246