### PR TITLE
`DocBuilderWrapper.change_output_file` return Tempfile

### DIFF
--- a/lib/doc_builder_testing/doc_builder_wrapper.rb
+++ b/lib/doc_builder_testing/doc_builder_wrapper.rb
@@ -35,16 +35,16 @@ class DocBuilderWrapper
   # @return [OoxmlParser::CommonDocumentStructure] parsed file
   def build_doc_and_parse(script_file)
     temp_script_data = DocBuilderWrapper.change_output_file(script_file)
-    build_doc(temp_script_data[:temp_script_file])
-    wait_file_creation(temp_script_data[:temp_output_file])
-    parse(temp_script_data[:temp_output_file])
+    build_doc(temp_script_data[:temp_script_file].path)
+    wait_file_creation(temp_script_data[:temp_output_file].path)
+    parse(temp_script_data[:temp_output_file].path)
   end
 
   def build_doc_without_parse(script_file)
     temp_script_data = DocBuilderWrapper.change_output_file(script_file)
-    build_doc(temp_script_data[:temp_script_file])
-    wait_file_creation(temp_script_data[:temp_output_file])
-    temp_script_data[:temp_output_file]
+    build_doc(temp_script_data[:temp_script_file].path)
+    wait_file_creation(temp_script_data[:temp_output_file].path)
+    temp_script_data[:temp_output_file].path
   end
 
   # Make a copy of script file, so no need to change output path on real file
@@ -59,7 +59,7 @@ class DocBuilderWrapper
     temp_script_file = Tempfile.new([File.basename(script_file), File.extname(script_file)])
     temp_script_file.write(script_file_content)
     temp_script_file.close
-    { temp_script_file: temp_script_file.path, temp_output_file: temp_output_file.path }
+    { temp_script_file: temp_script_file, temp_output_file: temp_output_file }
   end
 
   # Recognize format from script file

--- a/spec/doc_builder_wrapper_spec.rb
+++ b/spec/doc_builder_wrapper_spec.rb
@@ -28,7 +28,7 @@ describe 'My behaviour' do
 
     it 'check that changed file contain returned values' do
       rebuild_result = DocBuilderWrapper.change_output_file(simple_script)
-      expect(File.open(rebuild_result[:temp_script_file], 'rb').read).to include(rebuild_result[:temp_output_file])
+      expect(File.open(rebuild_result[:temp_script_file].path, 'rb').read).to include(rebuild_result[:temp_output_file].path)
     end
 
     it 'Check that temp script file is same format as original file' do


### PR DESCRIPTION
Before in return just string of Tempfiles, so tempfiles
themself was not referenced any more, so it is possible,
that garbage collector is catched those files and delete them.