### PR TITLE
Nokogiri 1.7 somehow broke installation.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ Encoding.default_external = Encoding::UTF_8
 Encoding.default_internal = Encoding::UTF_8
 
 source 'https://rubygems.org'
+gem 'nokogiri', '1.6.8.1'
 gem 'ooxml_parser', git: 'https://github.com/ONLYOFFICE/ooxml_parser'
 gem 'overcommit'
 gem 'parallel_tests'


### PR DESCRIPTION
Need to look at it later
See
http://buildserver/job/onlyoffice-documentserver-4.2.4/PRODUCT_NAME=documentserver-integration,label=buildserver-linux-2/3/console