### PR TITLE
Skip test for new methods

### DIFF
--- a/spec/xlsx/smoke/api_range_spec.rb
+++ b/spec/xlsx/smoke/api_range_spec.rb
@@ -65,18 +65,21 @@ describe 'ApiRange section tests' do
   end
 
   it 'ApiRange | SetBold method' do
+    skip('sdk-js older than 4.3 not support this. Remove after release of 4.3')
     xlsx = DocBuilderWrapper.new.build_doc_and_parse('asserts/js/xlsx/smoke/api_range/set_bold.js')
     expect(xlsx.worksheets.first.rows[1].cells[0].raw_text).to eq('Bold text')
     expect(xlsx.worksheets.first.rows[1].cells[0].style.font.font_style.bold).to be_truthy
   end
 
   it 'ApiRange | SetItalic method' do
+    skip('sdk-js older than 4.3 not support this. Remove after release of 4.3')
     xlsx = DocBuilderWrapper.new.build_doc_and_parse('asserts/js/xlsx/smoke/api_range/set_italic.js')
     expect(xlsx.worksheets.first.rows[1].cells[0].raw_text).to eq('Italicized text')
     expect(xlsx.worksheets.first.rows[1].cells[0].style.font.font_style.italic).to be_truthy
   end
 
   it 'ApiRange | SetUnderline method' do
+    skip('sdk-js older than 4.3 not support this. Remove after release of 4.3')
     xlsx = DocBuilderWrapper.new.build_doc_and_parse('asserts/js/xlsx/smoke/api_range/set_underline.js')
     expect(xlsx.worksheets.first.rows[1].cells[0].raw_text).to eq('The text underlined with a single line')
     expect(xlsx.worksheets.first.rows[3].cells[0].raw_text).to eq('Normal text')
@@ -85,6 +88,7 @@ describe 'ApiRange section tests' do
   end
 
   it 'ApiRange | SetStrikeout method' do
+    skip('sdk-js older than 4.3 not support this. Remove after release of 4.3')
     xlsx = DocBuilderWrapper.new.build_doc_and_parse('asserts/js/xlsx/smoke/api_range/set_strikeout.js')
     expect(xlsx.worksheets.first.rows[1].cells[0].raw_text).to eq('Struckout text')
     expect(xlsx.worksheets.first.rows[2].cells[0].raw_text).to eq('Normal text')
@@ -93,6 +97,7 @@ describe 'ApiRange section tests' do
   end
 
   it 'ApiRange | SetFillColor method' do
+    skip('sdk-js older than 4.3 not support this. Remove after release of 4.3')
     xlsx = DocBuilderWrapper.new.build_doc_and_parse('asserts/js/xlsx/smoke/api_range/set_fill_color.js')
     expect(xlsx.worksheets.first.rows[1].cells[0].style.fill_color.color).to eq(OoxmlParser::Color.new(255, 224, 204))
     expect(xlsx.worksheets.first.rows[1].cells[0].raw_text).to eq('This is the cell with a color set to its background')
@@ -101,6 +106,7 @@ describe 'ApiRange section tests' do
   end
 
   it 'ApiRange | SetNumberFormat method' do
+    skip('sdk-js older than 4.3 not support this. Remove after release of 4.3')
     pending 'https://github.com/ONLYOFFICE/ooxml_parser/issues/317'
     formats = ['General', '0.00', '$#,##0.00', '_($* #,##0.00_)', 'm/d/yyyy', '[$-F800]dddd, mmmm dd, yyyy', '[$-F400]h:mm:ss AM/PM', '0.00%', '0.00%', '# ?/?', '0.00E+00', 'Text']
     xlsx = DocBuilderWrapper.new.build_doc_and_parse('asserts/js/xlsx/smoke/api_range/set_number_format.js')
@@ -111,16 +117,19 @@ describe 'ApiRange section tests' do
   end
 
   it 'ApiRange | Merge method' do
+    skip('sdk-js older than 4.3 not support this. Remove after release of 4.3')
     xlsx = DocBuilderWrapper.new.build_doc_and_parse('asserts/js/xlsx/smoke/api_range/merge.js')
     expect(xlsx.worksheets.first.merge).to eq(['A3:E3', 'A4:E4', 'A5:E5', 'A6:E6', 'A7:E7', 'A8:E8', 'A9:E14'])
   end
 
   it 'ApiRange | Unmerge method' do
+    skip('sdk-js older than 4.3 not support this. Remove after release of 4.3')
     xlsx = DocBuilderWrapper.new.build_doc_and_parse('asserts/js/xlsx/smoke/api_range/unmerge.js')
     expect(xlsx.worksheets.first.merge).to eq(['A3:E3', 'A4:E4', 'A6:E6', 'A7:E7', 'A8:E8'])
   end
 
   it 'ApiRange | SetBorders method' do
+    skip('sdk-js older than 4.3 not support this. Remove after release of 4.3')
     xlsx = DocBuilderWrapper.new.build_doc_and_parse('asserts/js/xlsx/smoke/api_range/setborders.js')
     expect(xlsx.worksheets.first.rows[1].cells[0].style.borders.bottom.color).to eq(OoxmlParser::Color.new(49, 133, 154))
     expect(xlsx.worksheets.first.rows[1].cells[0].style.borders.bottom.style).to eq(:thick)
@@ -130,6 +139,7 @@ describe 'ApiRange section tests' do
   end
 
   it 'ApiRange | SetWrap method' do
+    skip('sdk-js older than 4.3 not support this. Remove after release of 4.3')
     xlsx = DocBuilderWrapper.new.build_doc_and_parse('asserts/js/xlsx/smoke/api_range/set_wrap.js')
     expect(xlsx.worksheets.first.rows[1].cells[0].style.alignment.wrap_text).to be_truthy
     expect(xlsx.worksheets.first.rows[1].cells[2].style.alignment.wrap_text).to be_falsey


### PR DESCRIPTION
Without this skip - cannot build bugfix 4.2.5, which has no such methods.