### PR TITLE
Force close and delete temp output file

### DIFF
--- a/lib/doc_builder_testing/doc_builder_wrapper.rb
+++ b/lib/doc_builder_testing/doc_builder_wrapper.rb
@@ -36,15 +36,15 @@ class DocBuilderWrapper
   def build_doc_and_parse(script_file)
     temp_script_data = DocBuilderWrapper.change_output_file(script_file)
     build_doc(temp_script_data[:temp_script_file].path)
-    wait_file_creation(temp_script_data[:temp_output_file].path)
-    parse(temp_script_data[:temp_output_file].path)
+    wait_file_creation(temp_script_data[:output_file])
+    parse(temp_script_data[:output_file])
   end
 
   def build_doc_without_parse(script_file)
     temp_script_data = DocBuilderWrapper.change_output_file(script_file)
     build_doc(temp_script_data[:temp_script_file].path)
-    wait_file_creation(temp_script_data[:temp_output_file].path)
-    temp_script_data[:temp_output_file].path
+    wait_file_creation(temp_script_data[:output_file])
+    temp_script_data[:output_file]
   end
 
   # Make a copy of script file, so no need to change output path on real file
@@ -55,11 +55,13 @@ class DocBuilderWrapper
     script_file_content = File.open(script_file, 'r').read
     output_format = DocBuilderWrapper.recognize_output_format(script_file_content)
     temp_output_file = Tempfile.new([File.basename(script_file), ".#{output_format}"])
-    script_file_content.gsub!(/^builder\.SaveFile.*$/, "builder.SaveFile(\"#{output_format}\", \"#{temp_output_file.path}\");")
+    output_path = temp_output_file.path
+    script_file_content.gsub!(/^builder\.SaveFile.*$/, "builder.SaveFile(\"#{output_format}\", \"#{output_path}\");")
+    temp_output_file.close!
     temp_script_file = Tempfile.new([File.basename(script_file), File.extname(script_file)])
     temp_script_file.write(script_file_content)
     temp_script_file.close
-    { temp_script_file: temp_script_file, temp_output_file: temp_output_file }
+    { temp_script_file: temp_script_file, output_file: output_path }
   end
 
   # Recognize format from script file

--- a/spec/doc_builder_wrapper_spec.rb
+++ b/spec/doc_builder_wrapper_spec.rb
@@ -28,7 +28,7 @@ describe 'My behaviour' do
 
     it 'check that changed file contain returned values' do
       rebuild_result = DocBuilderWrapper.change_output_file(simple_script)
-      expect(File.open(rebuild_result[:temp_script_file].path, 'rb').read).to include(rebuild_result[:temp_output_file].path)
+      expect(File.open(rebuild_result[:temp_script_file].path, 'rb').read).to include(rebuild_result[:output_file])
     end
 
     it 'Check that temp script file is same format as original file' do
@@ -38,7 +38,7 @@ describe 'My behaviour' do
 
     it 'Check that temp output file is docx' do
       rebuild_result = DocBuilderWrapper.change_output_file(simple_script)
-      expect(File.extname(rebuild_result[:temp_output_file])).to eq('.docx')
+      expect(File.extname(rebuild_result[:output_file])).to eq('.docx')
     end
   end
 


### PR DESCRIPTION
File used only for generation temp file name and should not be existing after
that
May cause conflictcs in windows, since file is blocked after that