### PR TITLE
Add correct path to license on windows platform

### DIFF
--- a/lib/doc_builder_testing/doc_builder_wrapper.rb
+++ b/lib/doc_builder_testing/doc_builder_wrapper.rb
@@ -37,6 +37,7 @@ class DocBuilderWrapper
 
   # @return [String] defualt path to license
   def license_path
+    return 'C:/ONLYOFFICE/DocumentBuilder/license' if Gem.win_platform?
     '/opt/onlyoffice/documentbuilder/license'
   end
 


### PR DESCRIPTION
Backlashed should be linux like.
Without it `Dir[path]` works incorrect