### PR TITLE
Use 0.7.1 filemagic

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem 'ooxml_parser', git: 'https://github.com/ONLYOFFICE/ooxml_parser'
 gem 'parallel_tests'
 gem 'rake', '>= 12'
 gem 'rspec'
+gem 'ruby-filemagic', '0.7.1'
 
 group :development do
   gem 'overcommit', require: false


### PR DESCRIPTION
Version 0.7.2 have no precompiled extra libs,
for version mingw32, so I have troubles to install it
and run on Windows.
See:
https://github.com/blackwinter/ruby-filemagic/issues/25