### PR TITLE
Update `asserts/js/docx/smoke/api/get_document.js`

### DIFF
--- a/asserts/js/docx/smoke/api/get_document.js
+++ b/asserts/js/docx/smoke/api/get_document.js
@@ -1,1 +1,8 @@
+builder.CreateFile("docx");
 var oDocument = Api.GetDocument();
+var oParagraph;
+oParagraph = Api.CreateParagraph();
+oParagraph.AddText("This is a new paragraph");
+oDocument.Push(oParagraph);
+builder.SaveFile("docx", "GetDocument.docx");
+builder.CloseFile();

--- a/spec/docx/smoke/api_base_spec.rb
+++ b/spec/docx/smoke/api_base_spec.rb
@@ -132,8 +132,7 @@ describe 'Api section tests' do
   end
 
   it 'Api | GetDocument method' do
-    pending('https://github.com/ONLYOFFICE/api.onlyoffice.com/issues/25')
     docx = builder.build_doc_and_parse('asserts/js/docx/smoke/api/get_document.js')
-    expect(docx).to be_with_data
+    expect(docx.elements[1].nonempty_runs.first.text).to eq('This is a new paragraph')
   end
 end


### PR DESCRIPTION
Documentation was added in
https://github.com/ONLYOFFICE/api.onlyoffice.com/commit/42b9ef0e3e6b33da0ac3c9cee13c2cf2f9b14821