### PR TITLE
Use size methods instead of deprecated sz

### DIFF
--- a/spec/docx/paragraph/tables/table_with_borders_and_background_spec.rb
+++ b/spec/docx/paragraph/tables/table_with_borders_and_background_spec.rb
@@ -6,15 +6,15 @@ describe 'Add table with borders and background' do
     expect(docx.elements[1].rows.length).to eq(3)
     expect(docx.elements[1].rows.first.cells.length).to eq(3)
     expect(docx.elements[1].rows.first.cells.first.elements.first.borders.between.color).to eq(OoxmlParser::Color.new(0, 0, 0))
-    expect(docx.elements[1].rows.first.cells.first.elements.first.borders.between.sz).to eq(OoxmlParser::OoxmlSize.new(0.5, :point))
+    expect(docx.elements[1].rows.first.cells.first.elements.first.borders.between.size).to eq(OoxmlParser::OoxmlSize.new(0.5, :point))
     expect(docx.elements[1].rows.first.cells.first.elements.first.borders.bottom.color).to eq(OoxmlParser::Color.new(0, 0, 0))
-    expect(docx.elements[1].rows.first.cells.first.elements.first.borders.bottom.sz).to eq(OoxmlParser::OoxmlSize.new(0.5, :point))
+    expect(docx.elements[1].rows.first.cells.first.elements.first.borders.bottom.size).to eq(OoxmlParser::OoxmlSize.new(0.5, :point))
     expect(docx.elements[1].rows.first.cells.first.elements.first.borders.left.color).to eq(OoxmlParser::Color.new(0, 0, 0))
-    expect(docx.elements[1].rows.first.cells.first.elements.first.borders.left.sz).to eq(OoxmlParser::OoxmlSize.new(0.5, :point))
+    expect(docx.elements[1].rows.first.cells.first.elements.first.borders.left.size).to eq(OoxmlParser::OoxmlSize.new(0.5, :point))
     expect(docx.elements[1].rows.first.cells.first.elements.first.borders.right.color).to eq(OoxmlParser::Color.new(0, 0, 0))
-    expect(docx.elements[1].rows.first.cells.first.elements.first.borders.right.sz).to eq(OoxmlParser::OoxmlSize.new(0.5, :point))
+    expect(docx.elements[1].rows.first.cells.first.elements.first.borders.right.size).to eq(OoxmlParser::OoxmlSize.new(0.5, :point))
     expect(docx.elements[1].rows.first.cells.first.elements.first.borders.top.color).to eq(OoxmlParser::Color.new(0, 0, 0))
-    expect(docx.elements[1].rows.first.cells.first.elements.first.borders.top.sz).to eq(OoxmlParser::OoxmlSize.new(0.5, :point))
+    expect(docx.elements[1].rows.first.cells.first.elements.first.borders.top.size).to eq(OoxmlParser::OoxmlSize.new(0.5, :point))
   end
 
   it 'Table with background' do

--- a/spec/docx/paragraph/tables/table_with_cell_borders_and_background_spec.rb
+++ b/spec/docx/paragraph/tables/table_with_cell_borders_and_background_spec.rb
@@ -11,12 +11,12 @@ describe 'Add table with cells with borders and background' do
     docx = builder.build_and_parse('asserts/js/docx/paragraph/tables/table_with_cell_borders.js')
     expect(docx.elements[1].rows.length).to eq(3)
     expect(docx.elements[1].rows[1].cells.first.properties.borders_properties.bottom.color).to eq(OoxmlParser::Color.new(0, 255, 0))
-    expect(docx.elements[1].rows[1].cells.first.properties.borders_properties.bottom.sz).to eq(OoxmlParser::OoxmlSize.new(8, :point))
+    expect(docx.elements[1].rows[1].cells.first.properties.borders_properties.bottom.size).to eq(OoxmlParser::OoxmlSize.new(8, :point))
     expect(docx.elements[1].rows[1].cells.first.properties.borders_properties.left.color).to eq(OoxmlParser::Color.new(0, 0, 255))
-    expect(docx.elements[1].rows[1].cells.first.properties.borders_properties.left.sz).to eq(OoxmlParser::OoxmlSize.new(4, :point))
+    expect(docx.elements[1].rows[1].cells.first.properties.borders_properties.left.size).to eq(OoxmlParser::OoxmlSize.new(4, :point))
     expect(docx.elements[1].rows[1].cells.first.properties.borders_properties.right.color).to eq(OoxmlParser::Color.new(0, 0, 255))
-    expect(docx.elements[1].rows[1].cells.first.properties.borders_properties.right.sz).to eq(OoxmlParser::OoxmlSize.new(2, :point))
+    expect(docx.elements[1].rows[1].cells.first.properties.borders_properties.right.size).to eq(OoxmlParser::OoxmlSize.new(2, :point))
     expect(docx.elements[1].rows[1].cells.first.properties.borders_properties.top.color).to eq(OoxmlParser::Color.new(0, 255, 0))
-    expect(docx.elements[1].rows[1].cells.first.properties.borders_properties.top.sz).to eq(OoxmlParser::OoxmlSize.new(4, :point))
+    expect(docx.elements[1].rows[1].cells.first.properties.borders_properties.top.size).to eq(OoxmlParser::OoxmlSize.new(4, :point))
   end
 end

--- a/spec/docx/smoke/api_paragraph_properties_spec.rb
+++ b/spec/docx/smoke/api_paragraph_properties_spec.rb
@@ -8,7 +8,7 @@ describe 'ApiParaPr section tests' do
   it 'ApiParaPr | SetBetweenBorder method' do
     docx = builder.build_and_parse('asserts/js/docx/smoke/api_para_pr/set_between_border.js')
     expect(docx.elements.first.borders.between.color).to eq(OoxmlParser::Color.new(0, 255, 0))
-    expect(docx.elements.first.borders.between.sz).to eq(OoxmlParser::OoxmlSize.new(24, :one_eighth_point))
+    expect(docx.elements.first.borders.between.size).to eq(OoxmlParser::OoxmlSize.new(24, :one_eighth_point))
     expect(docx.elements.first.borders.between.space).to eq(OoxmlParser::OoxmlSize.new(0.0, :point))
   end
 
@@ -16,7 +16,7 @@ describe 'ApiParaPr section tests' do
     docx = builder.build_and_parse('asserts/js/docx/smoke/api_para_pr/set_bottom_border.js')
     expect(docx.elements.first.borders.bottom.color).to eq(OoxmlParser::Color.new(0, 255, 0))
     expect(docx.elements.first.borders.bottom.space).to eq(OoxmlParser::OoxmlSize.new(0, :point))
-    expect(docx.elements.first.borders.bottom.sz).to eq(OoxmlParser::OoxmlSize.new(24, :one_eighth_point))
+    expect(docx.elements.first.borders.bottom.size).to eq(OoxmlParser::OoxmlSize.new(24, :one_eighth_point))
   end
 
   it 'ApiParaPr | SetContextualSpacing method' do
@@ -79,7 +79,7 @@ describe 'ApiParaPr section tests' do
     docx = builder.build_and_parse('asserts/js/docx/smoke/api_para_pr/set_left_border.js')
     expect(docx.elements.first.borders.left.color).to eq(OoxmlParser::Color.new(0, 255, 0))
     expect(docx.elements.first.borders.left.space).to eq(OoxmlParser::OoxmlSize.new(0.0, :point))
-    expect(docx.elements.first.borders.left.sz).to eq(OoxmlParser::OoxmlSize.new(24, :one_eighth_point))
+    expect(docx.elements.first.borders.left.size).to eq(OoxmlParser::OoxmlSize.new(24, :one_eighth_point))
   end
 
   it 'ApiParaPr | SetNumPr method' do
@@ -101,7 +101,7 @@ describe 'ApiParaPr section tests' do
     docx = builder.build_and_parse('asserts/js/docx/smoke/api_para_pr/set_right_border.js')
     expect(docx.elements.first.borders.right.color).to eq(OoxmlParser::Color.new(0, 255, 0))
     expect(docx.elements.first.borders.right.space).to eq(OoxmlParser::OoxmlSize.new(0, :point))
-    expect(docx.elements.first.borders.right.sz).to eq(OoxmlParser::OoxmlSize.new(24, :one_eighth_point))
+    expect(docx.elements.first.borders.right.size).to eq(OoxmlParser::OoxmlSize.new(24, :one_eighth_point))
   end
 
   it 'ApiParaPr | SetShd method' do
@@ -153,7 +153,7 @@ describe 'ApiParaPr section tests' do
   it 'ApiParaPr | SetTopBorder method' do
     docx = builder.build_and_parse('asserts/js/docx/smoke/api_para_pr/set_top_border.js')
     expect(docx.elements.first.borders.top.color).to eq(OoxmlParser::Color.new(0, 255, 0))
-    expect(docx.elements.first.borders.top.sz).to eq(OoxmlParser::OoxmlSize.new(24, :one_eighth_point))
+    expect(docx.elements.first.borders.top.size).to eq(OoxmlParser::OoxmlSize.new(24, :one_eighth_point))
     expect(docx.elements.first.borders.top.space).to eq(OoxmlParser::OoxmlSize.new(0, :point))
   end
 

--- a/spec/docx/smoke/api_paragraph_spec.rb
+++ b/spec/docx/smoke/api_paragraph_spec.rb
@@ -135,16 +135,16 @@ describe 'ApiParagraph section tests' do
     docx = builder.build_and_parse('asserts/js/docx/smoke/api_paragraph/set_between_border.js')
     expect(docx.elements.first.borders.between.color).to eq(OoxmlParser::Color.new(0, 255, 0))
     expect(docx.elements.first.borders.between.space).to eq(OoxmlParser::OoxmlSize.new(0, :point))
-    expect(docx.elements.first.borders.between.sz).to eq(OoxmlParser::OoxmlSize.new(24, :one_eighth_point))
+    expect(docx.elements.first.borders.between.size).to eq(OoxmlParser::OoxmlSize.new(24, :one_eighth_point))
     expect(docx.elements[1].borders.between.color).to eq(OoxmlParser::Color.new(255, 0, 0))
     expect(docx.elements[1].borders.between.space).to eq(OoxmlParser::OoxmlSize.new(10, :point))
-    expect(docx.elements[1].borders.between.sz).to eq(OoxmlParser::OoxmlSize.new(12, :one_eighth_point))
+    expect(docx.elements[1].borders.between.size).to eq(OoxmlParser::OoxmlSize.new(12, :one_eighth_point))
   end
 
   it 'ApiParagraph | SetBottomBorder method' do
     docx = builder.build_and_parse('asserts/js/docx/smoke/api_paragraph/set_bottom_border.js')
     expect(docx.elements.first.borders.bottom.color).to eq(OoxmlParser::Color.new(255, 0, 0))
-    expect(docx.elements.first.borders.bottom.sz).to eq(OoxmlParser::OoxmlSize.new(8, :one_eighth_point))
+    expect(docx.elements.first.borders.bottom.size).to eq(OoxmlParser::OoxmlSize.new(8, :one_eighth_point))
     expect(docx.elements.first.borders.bottom.space).to eq(OoxmlParser::OoxmlSize.new(0, :point))
   end
 
@@ -202,7 +202,7 @@ describe 'ApiParagraph section tests' do
     expect(docx.elements.first.borders.left.color).to eq(OoxmlParser::Color.new(0, 255, 0))
     expect(docx.elements.first.borders.left.val).to eq(:single)
     expect(docx.elements.first.borders.left.space).to eq(OoxmlParser::OoxmlSize.new(8, :point))
-    expect(docx.elements.first.borders.left.sz).to eq(OoxmlParser::OoxmlSize.new(16, :one_eighth_point))
+    expect(docx.elements.first.borders.left.size).to eq(OoxmlParser::OoxmlSize.new(16, :one_eighth_point))
   end
 
   it 'ApiParagraph | SetNumbering method' do
@@ -229,7 +229,7 @@ describe 'ApiParagraph section tests' do
     expect(docx.elements.first.borders.right.color).to eq(OoxmlParser::Color.new(255, 0, 0))
     expect(docx.elements.first.borders.right.val).to eq(:single)
     expect(docx.elements.first.borders.right.space).to eq(OoxmlParser::OoxmlSize.new(8, :point))
-    expect(docx.elements.first.borders.right.sz).to eq(OoxmlParser::OoxmlSize.new(16, :one_eighth_point))
+    expect(docx.elements.first.borders.right.size).to eq(OoxmlParser::OoxmlSize.new(16, :one_eighth_point))
   end
 
   it 'ApiParagraph | SetShd method' do
@@ -280,7 +280,7 @@ describe 'ApiParagraph section tests' do
   it 'ApiParagraph | SetTopBorder method' do
     docx = builder.build_and_parse('asserts/js/docx/smoke/api_paragraph/set_top_border.js')
     expect(docx.elements.first.borders.top.color).to eq(OoxmlParser::Color.new(0, 255, 0))
-    expect(docx.elements.first.borders.top.sz).to eq(OoxmlParser::OoxmlSize.new(24, :one_eighth_point))
+    expect(docx.elements.first.borders.top.size).to eq(OoxmlParser::OoxmlSize.new(24, :one_eighth_point))
     expect(docx.elements.first.borders.top.space).to eq(OoxmlParser::OoxmlSize.new(0, :point))
   end
 

--- a/spec/docx/smoke/api_table_cell_properties_spec.rb
+++ b/spec/docx/smoke/api_table_cell_properties_spec.rb
@@ -8,7 +8,7 @@ describe 'ApiTableCellPr section tests' do
   it 'ApiTableCellPr | SetCellBorderBottom method' do
     docx = builder.build_and_parse('asserts/js/docx/smoke/api_table_cell_pr/set_cell_border_bottom.js')
     expect(docx.elements[1].properties.table_style.table_cell_properties.borders_properties.bottom.color).to eq(OoxmlParser::Color.new(0, 0, 255))
-    expect(docx.elements[1].properties.table_style.table_cell_properties.borders_properties.bottom.sz).to eq(OoxmlParser::OoxmlSize.new(32, :one_eighth_point))
+    expect(docx.elements[1].properties.table_style.table_cell_properties.borders_properties.bottom.size).to eq(OoxmlParser::OoxmlSize.new(32, :one_eighth_point))
     expect(docx.elements[1].properties.table_style.table_cell_properties.borders_properties.bottom.val).to eq(:single)
     expect(docx.elements[1].properties.table_style.table_cell_properties.borders_properties.bottom.space).to eq(OoxmlParser::OoxmlSize.new(0, :point))
   end
@@ -16,7 +16,7 @@ describe 'ApiTableCellPr section tests' do
   it 'ApiTableCellPr | SetCellBorderLeft method' do
     docx = builder.build_and_parse('asserts/js/docx/smoke/api_table_cell_pr/set_cell_border_left.js')
     expect(docx.elements[1].properties.table_style.table_cell_properties.borders_properties.left.color).to eq(OoxmlParser::Color.new(0, 0, 255))
-    expect(docx.elements[1].properties.table_style.table_cell_properties.borders_properties.left.sz).to eq(OoxmlParser::OoxmlSize.new(32, :one_eighth_point))
+    expect(docx.elements[1].properties.table_style.table_cell_properties.borders_properties.left.size).to eq(OoxmlParser::OoxmlSize.new(32, :one_eighth_point))
     expect(docx.elements[1].properties.table_style.table_cell_properties.borders_properties.left.val).to eq(:single)
     expect(docx.elements[1].properties.table_style.table_cell_properties.borders_properties.left.space).to eq(OoxmlParser::OoxmlSize.new(0, :point))
   end
@@ -24,7 +24,7 @@ describe 'ApiTableCellPr section tests' do
   it 'ApiTableCellPr | SetCellBorderRight method' do
     docx = builder.build_and_parse('asserts/js/docx/smoke/api_table_cell_pr/set_cell_border_right.js')
     expect(docx.elements[1].properties.table_style.table_cell_properties.borders_properties.right.color).to eq(OoxmlParser::Color.new(0, 0, 255))
-    expect(docx.elements[1].properties.table_style.table_cell_properties.borders_properties.right.sz).to eq(OoxmlParser::OoxmlSize.new(32, :one_eighth_point))
+    expect(docx.elements[1].properties.table_style.table_cell_properties.borders_properties.right.size).to eq(OoxmlParser::OoxmlSize.new(32, :one_eighth_point))
     expect(docx.elements[1].properties.table_style.table_cell_properties.borders_properties.right.val).to eq(:single)
     expect(docx.elements[1].properties.table_style.table_cell_properties.borders_properties.right.space).to eq(OoxmlParser::OoxmlSize.new(0, :point))
   end
@@ -32,7 +32,7 @@ describe 'ApiTableCellPr section tests' do
   it 'ApiTableCellPr | SetCellBorderTop method' do
     docx = builder.build_and_parse('asserts/js/docx/smoke/api_table_cell_pr/set_cell_border_top.js')
     expect(docx.elements[1].properties.table_style.table_cell_properties.borders_properties.top.color).to eq(OoxmlParser::Color.new(0, 0, 255))
-    expect(docx.elements[1].properties.table_style.table_cell_properties.borders_properties.top.sz).to eq(OoxmlParser::OoxmlSize.new(32, :one_eighth_point))
+    expect(docx.elements[1].properties.table_style.table_cell_properties.borders_properties.top.size).to eq(OoxmlParser::OoxmlSize.new(32, :one_eighth_point))
     expect(docx.elements[1].properties.table_style.table_cell_properties.borders_properties.top.val).to eq(:single)
     expect(docx.elements[1].properties.table_style.table_cell_properties.borders_properties.top.space).to eq(OoxmlParser::OoxmlSize.new(0, :point))
   end

--- a/spec/docx/smoke/api_table_properties_spec.rb
+++ b/spec/docx/smoke/api_table_properties_spec.rb
@@ -34,7 +34,7 @@ describe 'ApiTablePr section tests' do
     docx = builder.build_and_parse('asserts/js/docx/smoke/api_table_pr/set_table_border_bottom.js')
     expect(docx.elements[1].properties.table_style.table_properties.table_borders.bottom.color).to eq(OoxmlParser::Color.new(0, 0, 255))
     expect(docx.elements[1].properties.table_style.table_properties.table_borders.bottom.val).to eq(:single)
-    expect(docx.elements[1].properties.table_style.table_properties.table_borders.bottom.sz).to eq(OoxmlParser::OoxmlSize.new(32.0, :one_eighth_point))
+    expect(docx.elements[1].properties.table_style.table_properties.table_borders.bottom.size).to eq(OoxmlParser::OoxmlSize.new(32.0, :one_eighth_point))
     expect(docx.elements[1].properties.table_style.table_properties.table_borders.bottom.space).to eq(OoxmlParser::OoxmlSize.new(0, :point))
   end
 
@@ -42,7 +42,7 @@ describe 'ApiTablePr section tests' do
     docx = builder.build_and_parse('asserts/js/docx/smoke/api_table_pr/set_table_border_inside_h.js')
     expect(docx.elements[1].properties.table_style.table_properties.table_borders.inside_horizontal.color).to eq(OoxmlParser::Color.new(0, 0, 255))
     expect(docx.elements[1].properties.table_style.table_properties.table_borders.inside_horizontal.val).to eq(:single)
-    expect(docx.elements[1].properties.table_style.table_properties.table_borders.inside_horizontal.sz).to eq(OoxmlParser::OoxmlSize.new(32.0, :one_eighth_point))
+    expect(docx.elements[1].properties.table_style.table_properties.table_borders.inside_horizontal.size).to eq(OoxmlParser::OoxmlSize.new(32.0, :one_eighth_point))
     expect(docx.elements[1].properties.table_style.table_properties.table_borders.inside_horizontal.space).to eq(OoxmlParser::OoxmlSize.new(0, :point))
   end
 
@@ -50,7 +50,7 @@ describe 'ApiTablePr section tests' do
     docx = builder.build_and_parse('asserts/js/docx/smoke/api_table_pr/set_table_border_inside_v.js')
     expect(docx.elements[1].properties.table_style.table_properties.table_borders.inside_vertical.color).to eq(OoxmlParser::Color.new(0, 0, 255))
     expect(docx.elements[1].properties.table_style.table_properties.table_borders.inside_vertical.val).to eq(:single)
-    expect(docx.elements[1].properties.table_style.table_properties.table_borders.inside_vertical.sz).to eq(OoxmlParser::OoxmlSize.new(32.0, :one_eighth_point))
+    expect(docx.elements[1].properties.table_style.table_properties.table_borders.inside_vertical.size).to eq(OoxmlParser::OoxmlSize.new(32.0, :one_eighth_point))
     expect(docx.elements[1].properties.table_style.table_properties.table_borders.inside_vertical.space).to eq(OoxmlParser::OoxmlSize.new(0, :point))
   end
 
@@ -58,7 +58,7 @@ describe 'ApiTablePr section tests' do
     docx = builder.build_and_parse('asserts/js/docx/smoke/api_table_pr/set_table_border_left.js')
     expect(docx.elements[1].properties.table_style.table_properties.table_borders.left.color).to eq(OoxmlParser::Color.new(0, 0, 255))
     expect(docx.elements[1].properties.table_style.table_properties.table_borders.left.val).to eq(:single)
-    expect(docx.elements[1].properties.table_style.table_properties.table_borders.left.sz).to eq(OoxmlParser::OoxmlSize.new(32.0, :one_eighth_point))
+    expect(docx.elements[1].properties.table_style.table_properties.table_borders.left.size).to eq(OoxmlParser::OoxmlSize.new(32.0, :one_eighth_point))
     expect(docx.elements[1].properties.table_style.table_properties.table_borders.left.space).to eq(OoxmlParser::OoxmlSize.new(0, :point))
   end
 
@@ -66,7 +66,7 @@ describe 'ApiTablePr section tests' do
     docx = builder.build_and_parse('asserts/js/docx/smoke/api_table_pr/set_table_border_right.js')
     expect(docx.elements[1].properties.table_style.table_properties.table_borders.right.color).to eq(OoxmlParser::Color.new(0, 0, 255))
     expect(docx.elements[1].properties.table_style.table_properties.table_borders.right.val).to eq(:single)
-    expect(docx.elements[1].properties.table_style.table_properties.table_borders.right.sz).to eq(OoxmlParser::OoxmlSize.new(32.0, :one_eighth_point))
+    expect(docx.elements[1].properties.table_style.table_properties.table_borders.right.size).to eq(OoxmlParser::OoxmlSize.new(32.0, :one_eighth_point))
     expect(docx.elements[1].properties.table_style.table_properties.table_borders.right.space).to eq(OoxmlParser::OoxmlSize.new(0, :point))
   end
 
@@ -74,7 +74,7 @@ describe 'ApiTablePr section tests' do
     docx = builder.build_and_parse('asserts/js/docx/smoke/api_table_pr/set_table_border_top.js')
     expect(docx.elements[1].properties.table_style.table_properties.table_borders.top.color).to eq(OoxmlParser::Color.new(0, 0, 255))
     expect(docx.elements[1].properties.table_style.table_properties.table_borders.top.val).to eq(:single)
-    expect(docx.elements[1].properties.table_style.table_properties.table_borders.top.sz).to eq(OoxmlParser::OoxmlSize.new(32.0, :one_eighth_point))
+    expect(docx.elements[1].properties.table_style.table_properties.table_borders.top.size).to eq(OoxmlParser::OoxmlSize.new(32.0, :one_eighth_point))
     expect(docx.elements[1].properties.table_style.table_properties.table_borders.top.space).to eq(OoxmlParser::OoxmlSize.new(0, :point))
   end
 

--- a/spec/docx/smoke/api_table_spec.rb
+++ b/spec/docx/smoke/api_table_spec.rb
@@ -83,7 +83,7 @@ describe 'ApiTable section tests' do
     docx = builder.build_and_parse('asserts/js/docx/smoke/api_table/set_table_border_bottom.js')
     expect(docx.elements[1].properties.table_borders.bottom.color).to eq(OoxmlParser::Color.new(0, 0, 255))
     expect(docx.elements[1].properties.table_borders.bottom.space).to eq(OoxmlParser::OoxmlSize.new(0, :point))
-    expect(docx.elements[1].properties.table_borders.bottom.sz).to eq(OoxmlParser::OoxmlSize.new(32, :one_eighth_point))
+    expect(docx.elements[1].properties.table_borders.bottom.size).to eq(OoxmlParser::OoxmlSize.new(32, :one_eighth_point))
     expect(docx.elements[1].properties.table_borders.bottom.val).to eq(:single)
   end
 
@@ -91,7 +91,7 @@ describe 'ApiTable section tests' do
     docx = builder.build_and_parse('asserts/js/docx/smoke/api_table/set_table_border_inside_h.js')
     expect(docx.elements[1].properties.table_borders.inside_horizontal.color).to eq(OoxmlParser::Color.new(255, 0, 0))
     expect(docx.elements[1].properties.table_borders.inside_horizontal.space).to eq(OoxmlParser::OoxmlSize.new(0, :point))
-    expect(docx.elements[1].properties.table_borders.inside_horizontal.sz).to eq(OoxmlParser::OoxmlSize.new(32, :one_eighth_point))
+    expect(docx.elements[1].properties.table_borders.inside_horizontal.size).to eq(OoxmlParser::OoxmlSize.new(32, :one_eighth_point))
     expect(docx.elements[1].properties.table_borders.inside_horizontal.val).to eq(:single)
   end
 
@@ -99,7 +99,7 @@ describe 'ApiTable section tests' do
     docx = builder.build_and_parse('asserts/js/docx/smoke/api_table/set_table_border_inside_v.js')
     expect(docx.elements[1].properties.table_borders.inside_vertical.color).to eq(OoxmlParser::Color.new(255, 0, 0))
     expect(docx.elements[1].properties.table_borders.inside_vertical.space).to eq(OoxmlParser::OoxmlSize.new(0, :point))
-    expect(docx.elements[1].properties.table_borders.inside_vertical.sz).to eq(OoxmlParser::OoxmlSize.new(32, :one_eighth_point))
+    expect(docx.elements[1].properties.table_borders.inside_vertical.size).to eq(OoxmlParser::OoxmlSize.new(32, :one_eighth_point))
     expect(docx.elements[1].properties.table_borders.inside_vertical.val).to eq(:single)
   end
 
@@ -107,7 +107,7 @@ describe 'ApiTable section tests' do
     docx = builder.build_and_parse('asserts/js/docx/smoke/api_table/set_table_border_left.js')
     expect(docx.elements[1].properties.table_borders.left.color).to eq(OoxmlParser::Color.new(0, 0, 255))
     expect(docx.elements[1].properties.table_borders.left.space).to eq(OoxmlParser::OoxmlSize.new(0, :point))
-    expect(docx.elements[1].properties.table_borders.left.sz).to eq(OoxmlParser::OoxmlSize.new(32, :one_eighth_point))
+    expect(docx.elements[1].properties.table_borders.left.size).to eq(OoxmlParser::OoxmlSize.new(32, :one_eighth_point))
     expect(docx.elements[1].properties.table_borders.left.val).to eq(:single)
   end
 
@@ -115,7 +115,7 @@ describe 'ApiTable section tests' do
     docx = builder.build_and_parse('asserts/js/docx/smoke/api_table/set_table_border_right.js')
     expect(docx.elements[1].properties.table_borders.right.color).to eq(OoxmlParser::Color.new(0, 0, 255))
     expect(docx.elements[1].properties.table_borders.right.space).to eq(OoxmlParser::OoxmlSize.new(0, :point))
-    expect(docx.elements[1].properties.table_borders.right.sz).to eq(OoxmlParser::OoxmlSize.new(32, :one_eighth_point))
+    expect(docx.elements[1].properties.table_borders.right.size).to eq(OoxmlParser::OoxmlSize.new(32, :one_eighth_point))
     expect(docx.elements[1].properties.table_borders.right.val).to eq(:single)
   end
 
@@ -123,7 +123,7 @@ describe 'ApiTable section tests' do
     docx = builder.build_and_parse('asserts/js/docx/smoke/api_table/set_table_border_top.js')
     expect(docx.elements[1].properties.table_borders.top.color).to eq(OoxmlParser::Color.new(0, 0, 255))
     expect(docx.elements[1].properties.table_borders.top.space).to eq(OoxmlParser::OoxmlSize.new(0, :point))
-    expect(docx.elements[1].properties.table_borders.top.sz).to eq(OoxmlParser::OoxmlSize.new(32, :one_eighth_point))
+    expect(docx.elements[1].properties.table_borders.top.size).to eq(OoxmlParser::OoxmlSize.new(32, :one_eighth_point))
     expect(docx.elements[1].properties.table_borders.top.val).to eq(:single)
   end
 


### PR DESCRIPTION
Since:
https://github.com/ONLYOFFICE/ooxml_parser/commit/63e0b1bcd72171e5660d6d9350de08eaa0be7737