### PR TITLE
Remove fail fast since problems

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,8 +3,6 @@ require 'bundler/setup'
 require 'rspec'
 require_relative '../lib/doc_builder_testing.rb'
 
-RSpec.configure { |c| c.fail_fast = true }
-
 def builder
   @builder ||= if ENV['BUILDER_PLATFORM'] == 'WEB'
                  WebDocBuilderWrapper.new


### PR DESCRIPTION
It's not very usefull, it's better to get all
failed test while executing parallel_rspec