### PR TITLE
Change test for new `Paragraph#RemoveAllElements` behavior

### DIFF
--- a/spec/docx/smoke/api_paragraph_spec.rb
+++ b/spec/docx/smoke/api_paragraph_spec.rb
@@ -136,8 +136,8 @@ describe 'ApiParagraph section tests' do
   it 'ApiParagraph | RemoveElement method' do
     docx = builder.build_and_parse('asserts/js/docx/smoke/api_paragraph/remove_element.js')
     if builder.semver == Semantic::Version.new('0.0.0') || builder.semver >= Semantic::Version.new('5.3.0')
-      expect(docx.elements.first.nonempty_runs[0].text).to eq('This is the third paragraph element (it will be removed from the paragraph and we will not see it). ')
-      expect(docx.elements.first.nonempty_runs[1].text).to eq('This is the fourth paragraph element - it became the third, because we removed the previous run from the paragraph. ')
+      expect(docx.elements.first.nonempty_runs[0].text).to eq('This is the first paragraph element.')
+      expect(docx.elements.first.nonempty_runs[1].text).to eq('This is the third paragraph element (it will be removed from the paragraph and we will not see it). ')
     else
       expect(docx.elements.first.nonempty_runs[0].text).to eq('This is the first paragraph element. ')
       expect(docx.elements.first.nonempty_runs[1].text).to eq('This is the second paragraph element. ')

--- a/spec/docx/smoke/api_paragraph_spec.rb
+++ b/spec/docx/smoke/api_paragraph_spec.rb
@@ -97,7 +97,11 @@ describe 'ApiParagraph section tests' do
 
   it 'ApiParagraph | GetElementsCount method' do
     docx = builder.build_and_parse('asserts/js/docx/smoke/api_paragraph/get_elements_count.js')
-    expect(docx.elements.first.nonempty_runs.first.text).to eq("Number of paragraph elements at this point: \t0\rNumber of paragraph elements after we added a text run: \t1")
+    if builder.semver == Semantic::Version.new('0.0.0') || builder.semver >= Semantic::Version.new('5.3.0')
+      expect(docx.elements.first.nonempty_runs.first.text).to eq("Number of paragraph elements at this point: \t1\rNumber of paragraph elements after we added a text run: \t2")
+    else
+      expect(docx.elements.first.nonempty_runs.first.text).to eq("Number of paragraph elements at this point: \t0\rNumber of paragraph elements after we added a text run: \t1")
+    end
   end
 
   it 'ApiParagraph | GetNumbering method' do
@@ -122,13 +126,22 @@ describe 'ApiParagraph section tests' do
 
   it 'ApiParagraph | RemoveAllElements method' do
     docx = builder.build_and_parse('asserts/js/docx/smoke/api_paragraph/remove_all_elements.js')
-    expect(docx.elements.first.nonempty_runs.first.text).to eq("This is the first document paragraph. We removed all the elements to get the number of paragraph elements at this point: 0. If we had not done that the number before this sentence would be \'1\'.")
+    if builder.semver == Semantic::Version.new('0.0.0') || builder.semver >= Semantic::Version.new('5.3.0')
+      expect(docx.elements.first.nonempty_runs.first.text).to eq("This is the first document paragraph. We removed all the elements to get the number of paragraph elements at this point: 1. If we had not done that the number before this sentence would be \'1\'.")
+    else
+      expect(docx.elements.first.nonempty_runs.first.text).to eq("This is the first document paragraph. We removed all the elements to get the number of paragraph elements at this point: 0. If we had not done that the number before this sentence would be \'1\'.")
+    end
   end
 
   it 'ApiParagraph | RemoveElement method' do
     docx = builder.build_and_parse('asserts/js/docx/smoke/api_paragraph/remove_element.js')
-    expect(docx.elements.first.nonempty_runs[0].text).to eq('This is the first paragraph element. ')
-    expect(docx.elements.first.nonempty_runs[1].text).to eq('This is the second paragraph element. ')
+    if builder.semver == Semantic::Version.new('0.0.0') || builder.semver >= Semantic::Version.new('5.3.0')
+      expect(docx.elements.first.nonempty_runs[0].text).to eq('This is the third paragraph element (it will be removed from the paragraph and we will not see it). ')
+      expect(docx.elements.first.nonempty_runs[1].text).to eq('This is the fourth paragraph element - it became the third, because we removed the previous run from the paragraph. ')
+    else
+      expect(docx.elements.first.nonempty_runs[0].text).to eq('This is the first paragraph element. ')
+      expect(docx.elements.first.nonempty_runs[1].text).to eq('This is the second paragraph element. ')
+    end
   end
 
   it 'ApiParagraph | SetBetweenBorder method' do

--- a/spec/docx/smoke/api_paragraph_spec.rb
+++ b/spec/docx/smoke/api_paragraph_spec.rb
@@ -135,11 +135,10 @@ describe 'ApiParagraph section tests' do
 
   it 'ApiParagraph | RemoveElement method' do
     docx = builder.build_and_parse('asserts/js/docx/smoke/api_paragraph/remove_element.js')
+    expect(docx.elements.first.nonempty_runs[0].text).to eq('This is the first paragraph element. ')
     if builder.semver == Semantic::Version.new('0.0.0') || builder.semver >= Semantic::Version.new('5.3.0')
-      expect(docx.elements.first.nonempty_runs[0].text).to eq('This is the first paragraph element.')
       expect(docx.elements.first.nonempty_runs[1].text).to eq('This is the third paragraph element (it will be removed from the paragraph and we will not see it). ')
     else
-      expect(docx.elements.first.nonempty_runs[0].text).to eq('This is the first paragraph element. ')
       expect(docx.elements.first.nonempty_runs[1].text).to eq('This is the second paragraph element. ')
     end
   end

--- a/spec/pptx/smoke/api_paragraph_spec.rb
+++ b/spec/pptx/smoke/api_paragraph_spec.rb
@@ -34,13 +34,22 @@ describe 'ApiParagraph section tests' do
   it 'ApiParagraph | GetElement method' do
     pptx = builder.build_and_parse('asserts/js/pptx/smoke/api_paragraph/get_element.js')
     expect(pptx.slides.first.elements.first.text_body.paragraphs.first.runs.size).to eq(3)
-    expect(pptx.slides.first.elements.first.text_body.paragraphs.first.runs[1].properties.font_style.bold).to be true
+    if builder.semver == Semantic::Version.new('0.0.0') || builder.semver >= Semantic::Version.new('5.3.0')
+      expect(pptx.slides.first.elements.first.text_body.paragraphs.first.runs[0].properties.font_style.bold).to be true
+    else
+      expect(pptx.slides.first.elements.first.text_body.paragraphs.first.runs[1].properties.font_style.bold).to be true
+    end
   end
 
   it 'ApiParagraph | GetElementsCount method' do
     pptx = builder.build_and_parse('asserts/js/pptx/smoke/api_paragraph/get_elements_count.js')
-    expect(pptx.slides.first.elements.first.text_body.paragraphs.first.runs.first.text).to eq("Number of paragraph elements at this point: \t0")
-    expect(pptx.slides.first.elements.first.text_body.paragraphs.first.runs.last.text).to eq("Number of paragraph elements after we added a text run: \t1")
+    if builder.semver == Semantic::Version.new('0.0.0') || builder.semver >= Semantic::Version.new('5.3.0')
+      expect(pptx.slides.first.elements.first.text_body.paragraphs.first.runs.first.text).to eq("Number of paragraph elements at this point: \t1")
+      expect(pptx.slides.first.elements.first.text_body.paragraphs.first.runs.last.text).to eq("Number of paragraph elements after we added a text run: \t2")
+    else
+      expect(pptx.slides.first.elements.first.text_body.paragraphs.first.runs.first.text).to eq("Number of paragraph elements at this point: \t0")
+      expect(pptx.slides.first.elements.first.text_body.paragraphs.first.runs.last.text).to eq("Number of paragraph elements after we added a text run: \t1")
+    end
   end
 
   it 'ApiParagraph | GetParaPr method' do

--- a/spec/xlsx/smoke/api_paragraph_spec.rb
+++ b/spec/xlsx/smoke/api_paragraph_spec.rb
@@ -34,7 +34,11 @@ describe 'ApiParagraph section tests' do
   it 'ApiParagraph | GetElement method' do
     xlsx = builder.build_and_parse('asserts/js/xlsx/smoke/api_paragraph/get_element.js')
     expect(xlsx.worksheets.first.drawings.first.shape.text_body.paragraphs.first.runs.size).to eq(3)
-    expect(xlsx.worksheets.first.drawings.first.shape.text_body.paragraphs.first.runs[1].properties.font_style.bold).to be true
+    if builder.semver == Semantic::Version.new('0.0.0') || builder.semver >= Semantic::Version.new('5.3.0')
+      expect(xlsx.worksheets.first.drawings.first.shape.text_body.paragraphs.first.runs[0].properties.font_style.bold).to be true
+    else
+      expect(xlsx.worksheets.first.drawings.first.shape.text_body.paragraphs.first.runs[1].properties.font_style.bold).to be true
+    end
   end
 
   it 'ApiParagraph | GetElementsCount method' do

--- a/spec/xlsx/smoke/api_paragraph_spec.rb
+++ b/spec/xlsx/smoke/api_paragraph_spec.rb
@@ -43,8 +43,13 @@ describe 'ApiParagraph section tests' do
 
   it 'ApiParagraph | GetElementsCount method' do
     xlsx = builder.build_and_parse('asserts/js/xlsx/smoke/api_paragraph/get_elements_count.js')
-    expect(xlsx.worksheets.first.drawings.first.shape.text_body.paragraphs.first.runs.first.text).to eq("Number of paragraph elements at this point: \t0")
-    expect(xlsx.worksheets.first.drawings.first.shape.text_body.paragraphs.first.runs[1].text).to eq("Number of paragraph elements after we added a text run: \t1")
+    if builder.semver == Semantic::Version.new('0.0.0') || builder.semver >= Semantic::Version.new('5.3.0')
+      expect(xlsx.worksheets.first.drawings.first.shape.text_body.paragraphs.first.runs.first.text).to eq("Number of paragraph elements at this point: \t1")
+      expect(xlsx.worksheets.first.drawings.first.shape.text_body.paragraphs.first.runs[1].text).to eq("Number of paragraph elements after we added a text run: \t2")
+    else
+      expect(xlsx.worksheets.first.drawings.first.shape.text_body.paragraphs.first.runs.first.text).to eq("Number of paragraph elements at this point: \t0")
+      expect(xlsx.worksheets.first.drawings.first.shape.text_body.paragraphs.first.runs[1].text).to eq("Number of paragraph elements after we added a text run: \t1")
+    end
   end
 
   it 'ApiParagraph | GetParaPr method' do


### PR DESCRIPTION
Since:
https://github.com/ONLYOFFICE/sdkjs/commit/814793088a33c57715942957548dcfb3ef8fcb32
calling `RemoveAllElement` will leave on element in document
So document will not be broken.