### PR TITLE
Correctly fix test for RemoveElements

### DIFF
--- a/spec/docx/smoke/api_paragraph_spec.rb
+++ b/spec/docx/smoke/api_paragraph_spec.rb
@@ -96,8 +96,9 @@ describe 'ApiParagraph section tests' do
   end
 
   it 'ApiParagraph | GetElementsCount method' do
+    skip if builder.semver < Semantic::Version.new('5.3.0')
     docx = builder.build_and_parse('asserts/js/docx/smoke/api_paragraph/get_elements_count.js')
-    expect(docx.elements.first.nonempty_runs.first.text).to eq("Number of paragraph elements at this point: \t0\rNumber of paragraph elements after we added a text run: \t1")
+    expect(docx.elements.first.nonempty_runs.first.text).to eq("Number of paragraph elements at this point: \t1\rNumber of paragraph elements after we added a text run: \t2")
   end
 
   it 'ApiParagraph | GetNumbering method' do
@@ -121,14 +122,16 @@ describe 'ApiParagraph section tests' do
   end
 
   it 'ApiParagraph | RemoveAllElements method' do
+    skip if builder.semver < Semantic::Version.new('5.3.0')
     docx = builder.build_and_parse('asserts/js/docx/smoke/api_paragraph/remove_all_elements.js')
-    expect(docx.elements.first.nonempty_runs.first.text).to eq("This is the first document paragraph. We removed all the elements to get the number of paragraph elements at this point: 0. If we had not done that the number before this sentence would be \'1\'.")
+    expect(docx.elements.first.nonempty_runs.first.text).to eq("This is the first document paragraph. We removed all the elements to get the number of paragraph elements at this point: 1. If we had not done that the number before this sentence would be \'1\'.")
   end
 
   it 'ApiParagraph | RemoveElement method' do
+    skip if builder.semver < Semantic::Version.new('5.3.0')
     docx = builder.build_and_parse('asserts/js/docx/smoke/api_paragraph/remove_element.js')
     expect(docx.elements.first.nonempty_runs[0].text).to eq('This is the first paragraph element. ')
-    expect(docx.elements.first.nonempty_runs[1].text).to eq('This is the second paragraph element. ')
+    expect(docx.elements.first.nonempty_runs[1].text).to eq('This is the third paragraph element (it will be removed from the paragraph and we will not see it). ')
   end
 
   it 'ApiParagraph | SetBetweenBorder method' do

--- a/spec/pptx/smoke/api_paragraph_spec.rb
+++ b/spec/pptx/smoke/api_paragraph_spec.rb
@@ -32,15 +32,17 @@ describe 'ApiParagraph section tests' do
   end
 
   it 'ApiParagraph | GetElement method' do
+    skip if builder.semver < Semantic::Version.new('5.3.0')
     pptx = builder.build_and_parse('asserts/js/pptx/smoke/api_paragraph/get_element.js')
     expect(pptx.slides.first.elements.first.text_body.paragraphs.first.runs.size).to eq(3)
-    expect(pptx.slides.first.elements.first.text_body.paragraphs.first.runs[1].properties.font_style.bold).to be true
+    expect(pptx.slides.first.elements.first.text_body.paragraphs.first.runs[0].properties.font_style.bold).to be true
   end
 
   it 'ApiParagraph | GetElementsCount method' do
+    skip if builder.semver < Semantic::Version.new('5.3.0')
     pptx = builder.build_and_parse('asserts/js/pptx/smoke/api_paragraph/get_elements_count.js')
-    expect(pptx.slides.first.elements.first.text_body.paragraphs.first.runs.first.text).to eq("Number of paragraph elements at this point: \t0")
-    expect(pptx.slides.first.elements.first.text_body.paragraphs.first.runs.last.text).to eq("Number of paragraph elements after we added a text run: \t1")
+    expect(pptx.slides.first.elements.first.text_body.paragraphs.first.runs.first.text).to eq("Number of paragraph elements at this point: \t1")
+    expect(pptx.slides.first.elements.first.text_body.paragraphs.first.runs.last.text).to eq("Number of paragraph elements after we added a text run: \t2")
   end
 
   it 'ApiParagraph | GetParaPr method' do

--- a/spec/xlsx/smoke/api_paragraph_spec.rb
+++ b/spec/xlsx/smoke/api_paragraph_spec.rb
@@ -32,15 +32,17 @@ describe 'ApiParagraph section tests' do
   end
 
   it 'ApiParagraph | GetElement method' do
+    skip if builder.semver < Semantic::Version.new('5.3.0')
     xlsx = builder.build_and_parse('asserts/js/xlsx/smoke/api_paragraph/get_element.js')
     expect(xlsx.worksheets.first.drawings.first.shape.text_body.paragraphs.first.runs.size).to eq(3)
-    expect(xlsx.worksheets.first.drawings.first.shape.text_body.paragraphs.first.runs[1].properties.font_style.bold).to be true
+    expect(xlsx.worksheets.first.drawings.first.shape.text_body.paragraphs.first.runs[0].properties.font_style.bold).to be true
   end
 
   it 'ApiParagraph | GetElementsCount method' do
+    skip if builder.semver < Semantic::Version.new('5.3.0')
     xlsx = builder.build_and_parse('asserts/js/xlsx/smoke/api_paragraph/get_elements_count.js')
-    expect(xlsx.worksheets.first.drawings.first.shape.text_body.paragraphs.first.runs.first.text).to eq("Number of paragraph elements at this point: \t0")
-    expect(xlsx.worksheets.first.drawings.first.shape.text_body.paragraphs.first.runs[1].text).to eq("Number of paragraph elements after we added a text run: \t1")
+    expect(xlsx.worksheets.first.drawings.first.shape.text_body.paragraphs.first.runs.first.text).to eq("Number of paragraph elements at this point: \t1")
+    expect(xlsx.worksheets.first.drawings.first.shape.text_body.paragraphs.first.runs[1].text).to eq("Number of paragraph elements after we added a text run: \t2")
   end
 
   it 'ApiParagraph | GetParaPr method' do


### PR DESCRIPTION
Solution in #213 was incorrect and reverted in #214
Since:
ONLYOFFICE/sdkjs@8147930
calling RemoveAllElement will leave on element in document
So document will not be broken.
But cannot be checked because version 0.0.0 is both actual for develop
and hotfix branches which cause documents to be differs