### PR TITLE
Compability with new image location in docx

### DIFF
--- a/spec/docx/paragraph/images/add_image_spec.rb
+++ b/spec/docx/paragraph/images/add_image_spec.rb
@@ -2,9 +2,11 @@ require 'spec_helper'
 describe 'Add image to paragraph' do
   it 'Add default image' do
     docx = builder.build_and_parse('asserts/js/docx/paragraph/images/create_image_base64.js')
-    expect(docx.elements.first.nonempty_runs.first.drawings.first.graphic.type).to eq(:picture)
-    expect(docx.elements.first.nonempty_runs.first.drawings.first.graphic.data.path_to_image.file_reference.content.length).to be > 1000
-    expect(docx.elements.first.nonempty_runs.first.drawings.first.properties.object_size.x).to eq(OoxmlParser::OoxmlSize.new(2_160_000, :emu))
-    expect(docx.elements.first.nonempty_runs.first.drawings.first.properties.object_size.y).to eq(OoxmlParser::OoxmlSize.new(1_260_000, :emu))
+    drawing = docx.elements.first.nonempty_runs.first.drawing
+    drawing ||= docx.elements.first.nonempty_runs.first.alternate_content.office2010_content
+    expect(drawing.graphic.type).to eq(:picture)
+    expect(drawing.graphic.data.path_to_image.file_reference.content.length).to be > 1000
+    expect(drawing.properties.object_size.x).to eq(OoxmlParser::OoxmlSize.new(2_160_000, :emu))
+    expect(drawing.properties.object_size.y).to eq(OoxmlParser::OoxmlSize.new(1_260_000, :emu))
   end
 end

--- a/spec/docx/smoke/api_base_spec.rb
+++ b/spec/docx/smoke/api_base_spec.rb
@@ -36,10 +36,12 @@ describe 'Api section tests' do
 
   it 'Api | CreateImage method' do
     docx = builder.build_and_parse('asserts/js/docx/smoke/api/create_image.js')
-    expect(docx.elements.first.nonempty_runs.first.drawings.first.graphic.type).to eq(:picture)
-    expect(docx.elements.first.nonempty_runs.first.drawings.first.graphic.data.path_to_image.file_reference.content.length).to be > 1000
-    expect(docx.elements.first.nonempty_runs.first.drawings.first.properties.object_size.x).to eq(OoxmlParser::OoxmlSize.new(2_160_000, :emu))
-    expect(docx.elements.first.nonempty_runs.first.drawings.first.properties.object_size.y).to eq(OoxmlParser::OoxmlSize.new(1_260_000, :emu))
+    drawing = docx.elements.first.nonempty_runs.first.drawing
+    drawing ||= docx.elements.first.nonempty_runs.first.alternate_content.office2010_content
+    expect(drawing.graphic.type).to eq(:picture)
+    expect(drawing.graphic.data.path_to_image.file_reference.content.length).to be > 1000
+    expect(drawing.properties.object_size.x).to eq(OoxmlParser::OoxmlSize.new(2_160_000, :emu))
+    expect(drawing.properties.object_size.y).to eq(OoxmlParser::OoxmlSize.new(1_260_000, :emu))
   end
 
   it 'Api | CreateLinearGradientFill method' do


### PR DESCRIPTION
Changed in DocumentServer 5.2.8
See:
https://github.com/ONLYOFFICE/testing-documentserver/pull/2456