### PR TITLE
skip test not working on develop

### DIFF
--- a/spec/xlsx/smoke/api_range_spec.rb
+++ b/spec/xlsx/smoke/api_range_spec.rb
@@ -179,6 +179,7 @@ describe 'ApiRange section tests' do
   end
 
   it 'ApiRange | SetFillColor method' do
+    skip('Not working on develop because need newest core')
     xlsx = builder.build_and_parse('asserts/js/xlsx/smoke/api_range/set_fill_color.js')
     expect(xlsx.worksheets.first.rows[1].cells[0].style.fill_color.pattern_fill.background_color).to eq(OoxmlParser::Color.new(255, 224, 204))
     expect(xlsx.worksheets.first.rows[1].cells[0].style.fill_color.pattern_fill.foreground_color).to eq(OoxmlParser::Color.new(255, 224, 204))


### PR DESCRIPTION
According to Sergey Konvalov it need newest core
but it may be troubles to get it work
Since:
https://github.com/ONLYOFFICE/sdkjs/commit/95b141d0ff5c8b3cc01a488a71791e601c6cc01e