### PR TITLE
Remove dependency of `ruby-filemagic`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,6 @@ gem 'ooxml_parser', git: 'https://github.com/ONLYOFFICE/ooxml_parser'
 gem 'parallel_tests'
 gem 'rake', '>= 12'
 gem 'rspec'
-gem 'ruby-filemagic', '0.7.2'
 gem 'semantic'
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,7 +90,6 @@ DEPENDENCIES
   rake (>= 12)
   rspec
   rubocop
-  ruby-filemagic (= 0.7.2)
   semantic
 
 BUNDLED WITH


### PR DESCRIPTION
This gem is already required by `ooxml_parser`
Also currently there is no known way to install this
gem on Windows with current stable ruby 2.6
This gem provide not very important functions, so
can work without it.
See:
https://github.com/ONLYOFFICE/ooxml_parser/pull/575