### PR TITLE
Remove param for updating DocumentBuilder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,7 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys CB2DE8E5
 RUN echo "deb http://download.onlyoffice.com/repo/debian squeeze main" >> /etc/apt/sources.list.d/onlyoffice.list && \
     apt-get -y update && \
     apt-get -y install onlyoffice-documentbuilder
-CMD /bin/bash -l -c "[ ! -z \"$UPDATE_DOCUMENTBUILDER\" ] && apt-get -y update && apt-get --allow-unauthenticated -y install onlyoffice-documentbuilder; \
-                     onlyoffice-documentbuilder; \
+CMD /bin/bash -l -c "onlyoffice-documentbuilder; \
                      cd /doc-builder-testing; \
                      bundle update; \
                      rake"

--- a/dockerfiles/centos/Dockerfile
+++ b/dockerfiles/centos/Dockerfile
@@ -10,8 +10,7 @@ WORKDIR /doc-builder-testing
 RUN /bin/bash -l -c 'bundle install --without development'
 RUN yum -y install https://download.onlyoffice.com/repo/centos/main/noarch/onlyoffice-repo.noarch.rpm
 RUN yum -y install onlyoffice-documentbuilder
-CMD /bin/bash -l -c "[ ! -z \"$UPDATE_DOCUMENTBUILDER\" ] && yum clean all && yum -y update onlyoffice-documentbuilder; \
-                     onlyoffice-documentbuilder; \
+CMD /bin/bash -l -c "onlyoffice-documentbuilder; \
                      cd /doc-builder-testing; \
                      bundle update; \
                      bundle exec parallel_rspec spec"

--- a/dockerfiles/debian-develop/Dockerfile
+++ b/dockerfiles/debian-develop/Dockerfile
@@ -13,8 +13,7 @@ RUN echo "deb [trusted=yes]  http://repo-doc-onlyoffice-com.s3.amazonaws.com/ubu
     apt-get -y update && \
     apt-get -y install onlyoffice-documentbuilder
 
-CMD /bin/bash -l -c "[ ! -z \"$UPDATE_DOCUMENTBUILDER\" ] && apt-get -y update && apt-get -y install onlyoffice-documentbuilder; \
-                     onlyoffice-documentbuilder; \
+CMD /bin/bash -l -c "onlyoffice-documentbuilder; \
                      cd /doc-builder-testing; \
                      bundle update; \
                      bundle exec parallel_rspec spec"


### PR DESCRIPTION
It was introduced long time ago and
I think it newer used as it should.