### PR TITLE
Remove `-l` bash param

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,12 +8,12 @@ RUN apt-get update && apt-get -y -q install libmagic-dev
 RUN gem install bundler
 COPY . /doc-builder-testing
 WORKDIR /doc-builder-testing
-RUN /bin/bash -l -c 'bundle install --without development'
+RUN /bin/bash -c 'bundle install --without development'
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys CB2DE8E5
 RUN echo "deb http://download.onlyoffice.com/repo/debian squeeze main" >> /etc/apt/sources.list.d/onlyoffice.list && \
     apt-get -y update && \
     apt-get -y install onlyoffice-documentbuilder
-CMD /bin/bash -l -c "onlyoffice-documentbuilder; \
-                     cd /doc-builder-testing; \
-                     bundle update; \
-                     rake"
+CMD /bin/bash -c "onlyoffice-documentbuilder; \
+                  cd /doc-builder-testing; \
+                  bundle update; \
+                  rake"

--- a/dockerfiles/centos/Dockerfile
+++ b/dockerfiles/centos/Dockerfile
@@ -7,10 +7,10 @@ RUN yum -y install git gcc make file-devel zlib-devel google-crosextra-carlito-f
 RUN gem install bundler
 COPY . /doc-builder-testing
 WORKDIR /doc-builder-testing
-RUN /bin/bash -l -c 'bundle install --without development'
+RUN /bin/bash -c 'bundle install --without development'
 RUN yum -y install https://download.onlyoffice.com/repo/centos/main/noarch/onlyoffice-repo.noarch.rpm
 RUN yum -y install onlyoffice-documentbuilder
-CMD /bin/bash -l -c "onlyoffice-documentbuilder; \
-                     cd /doc-builder-testing; \
-                     bundle update; \
-                     bundle exec parallel_rspec spec"
+CMD /bin/bash -c "onlyoffice-documentbuilder; \
+                  cd /doc-builder-testing; \
+                  bundle update; \
+                  bundle exec parallel_rspec spec"

--- a/dockerfiles/debian-archive/Dockerfile
+++ b/dockerfiles/debian-archive/Dockerfile
@@ -14,7 +14,7 @@ COPY . /doc-builder-testing
 COPY asserts/documentbuilder /usr/bin/documentbuilder
 RUN chmod +x /usr/bin/documentbuilder
 WORKDIR /doc-builder-testing
-RUN /bin/bash -l -c 'bundle install --without development'
-CMD /bin/bash -l -c "documentbuilder; \
-                     bundle update; \
-                     bundle exec parallel_rspec spec"
+RUN /bin/bash -c 'bundle install --without development'
+CMD /bin/bash -c "documentbuilder; \
+                  bundle update; \
+                  bundle exec parallel_rspec spec"

--- a/dockerfiles/debian-develop/Dockerfile
+++ b/dockerfiles/debian-develop/Dockerfile
@@ -8,12 +8,12 @@ RUN apt-get update && apt-get -y -q install libmagic-dev
 RUN gem install bundler
 COPY . /doc-builder-testing
 WORKDIR /doc-builder-testing
-RUN /bin/bash -l -c 'bundle install --without development'
+RUN /bin/bash -c 'bundle install --without development'
 RUN echo "deb [trusted=yes]  http://repo-doc-onlyoffice-com.s3.amazonaws.com/ubuntu/trusty/onlyoffice-documentbuilder/origin/develop/latest/amd64/ repo/" >> /etc/apt/sources.list.d/onlyoffice.list && \
     apt-get -y update && \
     apt-get -y install onlyoffice-documentbuilder
 
-CMD /bin/bash -l -c "onlyoffice-documentbuilder; \
-                     cd /doc-builder-testing; \
-                     bundle update; \
-                     bundle exec parallel_rspec spec"
+CMD /bin/bash -c "onlyoffice-documentbuilder; \
+                  cd /doc-builder-testing; \
+                  bundle update; \
+                  bundle exec parallel_rspec spec"


### PR DESCRIPTION
Don't know why it was ever used, seems it's do nothing.
Maybe related to #253, but it was removed