### PR TITLE
Use `onlyoffice_pdf_parser` as gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ Encoding.default_internal = Encoding::UTF_8
 
 source 'https://rubygems.org'
 gem 'jwt'
-gem 'onlyoffice_pdf_parser', git: 'https://github.com/onlyoffice-testing-robot/onlyoffice_pdf_parser'
+gem 'onlyoffice_pdf_parser'
 gem 'ooxml_parser', git: 'https://github.com/ONLYOFFICE/ooxml_parser'
 gem 'parallel_tests'
 gem 'rake', '>= 12'


### PR DESCRIPTION
Remove downloading from git
Gem is pretty stable now and I downloading gem directly
can save some time