### PR TITLE
Remove bundle update from Docker `CMD`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,5 +15,4 @@ RUN echo "deb http://download.onlyoffice.com/repo/debian squeeze main" >> /etc/a
     apt-get -y install onlyoffice-documentbuilder
 CMD /bin/bash -c "onlyoffice-documentbuilder; \
                   cd /doc-builder-testing; \
-                  bundle update; \
                   rake"

--- a/dockerfiles/centos-7/Dockerfile
+++ b/dockerfiles/centos-7/Dockerfile
@@ -16,5 +16,4 @@ RUN yum -y install https://download.onlyoffice.com/repo/centos/main/noarch/onlyo
 RUN yum -y install onlyoffice-documentbuilder
 CMD /bin/bash -c "onlyoffice-documentbuilder; \
                   cd /doc-builder-testing; \
-                  bundle update; \
                   bundle exec parallel_rspec spec"

--- a/dockerfiles/centos-8/Dockerfile
+++ b/dockerfiles/centos-8/Dockerfile
@@ -29,5 +29,4 @@ RUN yum -y install https://download.onlyoffice.com/repo/centos/main/noarch/onlyo
 RUN yum -y install onlyoffice-documentbuilder
 CMD /bin/bash -c "onlyoffice-documentbuilder; \
                   cd /doc-builder-testing; \
-                  bundle update; \
                   bundle exec parallel_rspec spec"

--- a/dockerfiles/debian-archive/Dockerfile
+++ b/dockerfiles/debian-archive/Dockerfile
@@ -16,5 +16,4 @@ RUN chmod +x /usr/bin/documentbuilder
 WORKDIR /doc-builder-testing
 RUN /bin/bash -c 'bundle install --without development'
 CMD /bin/bash -c "documentbuilder; \
-                  bundle update; \
                   bundle exec parallel_rspec spec"

--- a/dockerfiles/debian-develop/Dockerfile
+++ b/dockerfiles/debian-develop/Dockerfile
@@ -15,5 +15,4 @@ RUN echo "deb [trusted=yes]  http://repo-doc-onlyoffice-com.s3.amazonaws.com/ubu
 
 CMD /bin/bash -c "onlyoffice-documentbuilder; \
                   cd /doc-builder-testing; \
-                  bundle update; \
                   bundle exec parallel_rspec spec"


### PR DESCRIPTION
Since we're using Dependabot in this project
there is no need to update dependencies on runtime.
Also this lines cause troubles if some dependency is broken
and auto-updated without CI check