### PR TITLE
`onlyoffice_pdf_parser` require `pdfinfo`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ FROM ruby:2.6
 MAINTAINER Pavel.Lobashov "shockwavenn@gmail.com"
 
 RUN apt-get update && apt-get -y -q install git curl
-RUN apt-get update && apt-get -y -q install libmagic-dev
+RUN apt-get update && apt-get -y -q install libmagic-dev \
+                                            poppler-utils
 
 RUN gem install bundler
 COPY . /doc-builder-testing

--- a/dockerfiles/centos-7/Dockerfile
+++ b/dockerfiles/centos-7/Dockerfile
@@ -7,7 +7,8 @@ RUN yum -y install file-devel \
                    gcc \
                    git \
                    ImageMagick-devel \
-                   make
+                   make \
+                   poppler-utils
 RUN gem install bundler
 COPY . /doc-builder-testing
 WORKDIR /doc-builder-testing

--- a/dockerfiles/centos-8/Dockerfile
+++ b/dockerfiles/centos-8/Dockerfile
@@ -11,6 +11,7 @@ RUN yum -y install file-devel \
                    gcc \
                    git \
                    ImageMagick-devel \
+                   poppler-utils \
                    # /usr/lib/rpm/redhat/redhat-hardened-cc1: No such file or directory
                    # on gems install
                    redhat-rpm-config \

--- a/dockerfiles/debian-archive/Dockerfile
+++ b/dockerfiles/debian-archive/Dockerfile
@@ -3,7 +3,8 @@ FROM ruby:2.6
 MAINTAINER Pavel.Lobashov "shockwavenn@gmail.com"
 
 RUN apt-get update && apt-get -y -q install git curl wget
-RUN apt-get update && apt-get -y -q install libmagic-dev
+RUN apt-get update && apt-get -y -q install libmagic-dev \
+                                            poppler-utils
 
 RUN gem install bundler
 RUN wget https://download.onlyoffice.com/install/desktop/docbuilder/documentbuilder-x64.tar.gz

--- a/dockerfiles/debian-develop/Dockerfile
+++ b/dockerfiles/debian-develop/Dockerfile
@@ -3,7 +3,8 @@ FROM ruby:2.6
 MAINTAINER Pavel.Lobashov "shockwavenn@gmail.com"
 
 RUN apt-get update && apt-get -y -q install git curl
-RUN apt-get update && apt-get -y -q install libmagic-dev
+RUN apt-get update && apt-get -y -q install libmagic-dev \
+                                            poppler-utils
 
 RUN gem install bundler
 COPY . /doc-builder-testing


### PR DESCRIPTION
`pdfinfo` program is part of `poppler-utils` package

Without it some pdf parsing test failing without no reason