### PR TITLE
Use ruby 2.7 where possible

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6
+FROM ruby:2.7
 
 MAINTAINER Pavel.Lobashov "shockwavenn@gmail.com"
 

--- a/dockerfiles/centos-7/Dockerfile
+++ b/dockerfiles/centos-7/Dockerfile
@@ -2,7 +2,7 @@ FROM centos:7
 
 MAINTAINER Pavel.Lobashov "shockwavenn@gmail.com"
 
-RUN yum -y install https://github.com/feedforce/ruby-rpm/releases/download/2.4.0/ruby-2.4.0-1.el7.centos.x86_64.rpm
+RUN yum -y install https://github.com/feedforce/ruby-rpm/releases/download/2.7.1/ruby-2.7.1-1.el7.centos.x86_64.rpm
 RUN yum -y install file-devel \
                    gcc \
                    git \

--- a/dockerfiles/debian-archive/Dockerfile
+++ b/dockerfiles/debian-archive/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6
+FROM ruby:2.7
 
 MAINTAINER Pavel.Lobashov "shockwavenn@gmail.com"
 

--- a/dockerfiles/debian-develop/Dockerfile
+++ b/dockerfiles/debian-develop/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6
+FROM ruby:2.7
 
 MAINTAINER Pavel.Lobashov "shockwavenn@gmail.com"
 


### PR DESCRIPTION
Didn't find an easy way to install ruby 2.7 in Centos 8
withouy using RVM, so just use ruby 2.5 which is still supported