### PR TITLE
Remove lines about encoding from `Gemfile`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-Encoding.default_external = Encoding::UTF_8
-Encoding.default_internal = Encoding::UTF_8
-
 source 'https://rubygems.org'
 gem 'jwt'
 gem 'onlyoffice_pdf_parser'


### PR DESCRIPTION
Seems those are very old lines and were added
a long time ago and should not be needed