### PR TITLE
Solving a minor problem after adapting the tests to version 7.2

### DIFF
--- a/asserts/js/docx/smoke/api_document/get_review_report.js
+++ b/asserts/js/docx/smoke/api_document/get_review_report.js
@@ -16,8 +16,8 @@ for (var sUserName in oReviewReport)
 {
     nRows += oReviewReport[sUserName].length;
 }
-nCols = 4;
-oTable = Api.CreateTable(nCols, nRows);
+var nCols = 4;
+var oTable = Api.CreateTable(nCols, nRows);
 oDocument.Push(oTable);
 function privateFillCell(nCurRow, nCurCol, sText)
 {

--- a/spec/docx/smoke/api_document_spec.rb
+++ b/spec/docx/smoke/api_document_spec.rb
@@ -99,7 +99,7 @@ describe 'ApiDocument section tests' do
     skip('Cannot use OpenFile in web version') if web_builder?
     docx = builder.build_and_parse('asserts/js/docx/smoke/api_document/get_review_report.js')
     expect(docx.elements[3].rows[1].cells[2].elements
-               .first.nonempty_runs.first.text).to eq('Removed text')
+               .first.nonempty_runs.first.text).to eq('Formatted text')
   end
 
   it 'ApiDocument | GetStyle method' do


### PR DESCRIPTION
Pavel in commit https://github.com/ONLYOFFICE/doc-builder-testing/commit/c2ff3b4659cf73609cb816dedde1364b113c8b3f change rows but not change value

![image](https://user-images.githubusercontent.com/60688343/204789054-2e3ee764-5c6a-4db2-977c-a60bc6163901.png)

Judging by the script, the report is generated correctly.