### PR TITLE
Retry on http error 500 with onlyoffice.gpg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,9 @@ COPY . /doc-builder-testing
 WORKDIR /doc-builder-testing
 RUN bundle config set without 'development' && \
     bundle install
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys CB2DE8E5
-RUN echo "deb http://download.onlyoffice.com/repo/debian squeeze main" >> /etc/apt/sources.list.d/onlyoffice.list && \
+RUN wget --retry-on-http-error=500 -qO - "http://keyserver.ubuntu.com/pks/lookup?op=get&search=0xe09ca29f6e178040ef22b4098320ca65cb2de8e5" | \
+    gpg --dearmor > /usr/share/keyrings/onlyoffice.gpg
+RUN echo "deb [signed-by=/usr/share/keyrings/onlyoffice.gpg] http://download.onlyoffice.com/repo/debian squeeze main" >> /etc/apt/sources.list.d/onlyoffice.list && \
     apt-get -y update && \
     apt-get -y install onlyoffice-documentbuilder
 CMD /bin/bash -c "onlyoffice-documentbuilder; \

--- a/dockerfiles/debian-next-release/Dockerfile
+++ b/dockerfiles/debian-next-release/Dockerfile
@@ -1,7 +1,7 @@
 FROM ruby:3.2
 
 MAINTAINER Pavel.Lobashov "shockwavenn@gmail.com"
-ENV VERSION="7.3.0-*"
+ENV VERSION="7.3.3-*"
 
 RUN apt-get update && apt-get -y -q install git curl
 RUN apt-get update && apt-get -y -q install libmagic-dev \


### PR DESCRIPTION
Sometimes get request for keyserver.ubuntu.com returns:

```bash
2023-02-17 10:11:02 ERROR 500: Internal Server Error.
```

Instead of correct key data