### PR TITLE
Run tests `:critical` on centos-7, debian-develop, debian-next-release

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -18,7 +18,7 @@ jobs:
         run: rubocop
       - name: Check that code 100% documented
         run: yardoc . | grep -q '100.00% documented'
-  test:
+  base_dockerfile:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -26,7 +26,7 @@ jobs:
         run: |
           docker build -t doc-builder-testing .
           docker run doc-builder-testing
-  build:
+  build_ubuntu:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -38,4 +38,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Dockerfile ${{ matrix.dockerfiles }} Test
-        run: docker build -f ${{ matrix.dockerfiles }} .
+        run: |
+          docker build -f ${{ matrix.dockerfiles }} .
+          docker run ${{ matrix.dockerfiles }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -18,7 +18,7 @@ jobs:
         run: rubocop
       - name: Check that code 100% documented
         run: yardoc . | grep -q '100.00% documented'
-  base_dockerfile:
+  latest_run:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -26,18 +26,17 @@ jobs:
         run: |
           docker build -t doc-builder-testing .
           docker run doc-builder-testing
-  build_ubuntu:
+  run:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        dockerfiles:
-          - 'Dockerfile'
-          - 'dockerfiles/centos-7/Dockerfile'
-          - 'dockerfiles/debian-develop/Dockerfile'
-          - 'dockerfiles/debian-next-release/Dockerfile'
+        dockerfiles: [dockerfiles/debian-archive/Dockerfile,
+                      dockerfiles/centos-7/Dockerfile,
+                      dockerfiles/debian-develop/Dockerfile,
+                      dockerfiles/debian-next-release/Dockerfile]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Dockerfile ${{ matrix.dockerfiles }} Test
         run: |
-          docker build -f ${{ matrix.dockerfiles }} .
-          docker run ${{ matrix.dockerfiles }}
+          docker build -t doc-builder-testing -f ${{ matrix.dockerfiles }} .
+          docker run doc-builder-testing

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -18,25 +18,26 @@ jobs:
         run: rubocop
       - name: Check that code 100% documented
         run: yardoc . | grep -q '100.00% documented'
-  latest_run:
+
+  run_latest:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Running test inside doc-builder-testing
         run: |
           docker build -t doc-builder-testing .
           docker run doc-builder-testing
+
   run:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        dockerfiles: [dockerfiles/debian-archive/Dockerfile,
-                      dockerfiles/centos-7/Dockerfile,
+        dockerfiles: [dockerfiles/centos-7/Dockerfile,
                       dockerfiles/debian-develop/Dockerfile,
                       dockerfiles/debian-next-release/Dockerfile]
     steps:
       - uses: actions/checkout@v3
-      - name: Dockerfile ${{ matrix.dockerfiles }} Test
+      - name: Dockerfile ${{ matrix.dockerfiles }}
         run: |
           docker build -t doc-builder-testing -f ${{ matrix.dockerfiles }} .
           docker run doc-builder-testing

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Check that code 100% documented
         run: yardoc . | grep -q '100.00% documented'
 
-  run_latest:
+  run_all_specs_in_default_docker:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -28,7 +28,7 @@ jobs:
           docker build -t doc-builder-testing .
           docker run doc-builder-testing
 
-  run:
+  run_critical_in_all_dockerfiles:
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -32,9 +32,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        dockerfiles: [dockerfiles/centos-7/Dockerfile,
-                      dockerfiles/debian-develop/Dockerfile,
-                      dockerfiles/debian-next-release/Dockerfile]
+        dockerfiles:
+          - "dockerfiles/centos-7/Dockerfile"
+          - "dockerfiles/debian-develop/Dockerfile"
+          - "dockerfiles/debian-next-release/Dockerfile"
     steps:
       - uses: actions/checkout@v3
       - name: Dockerfile ${{ matrix.dockerfiles }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,6 @@ RUN mv /tmp/onlyoffice.gpg /usr/share/keyrings/onlyoffice.gpg
 RUN echo "deb [signed-by=/usr/share/keyrings/onlyoffice.gpg] http://download.onlyoffice.com/repo/debian squeeze main" >> /etc/apt/sources.list.d/onlyoffice.list && \
     apt-get -y update && \
     apt-get -y install onlyoffice-documentbuilder
-CMD /bin/bash -c "onlyoffice-documentbuilder; \
+CMD /bin/bash -c "onlyoffice-documentbuilder -v; \
                   cd /doc-builder-testing; \
                   rake"

--- a/dockerfiles/centos-7/Dockerfile
+++ b/dockerfiles/centos-7/Dockerfile
@@ -16,6 +16,6 @@ RUN bundle config set without 'development' && \
     bundle install
 RUN yum -y install https://download.onlyoffice.com/repo/centos/main/noarch/onlyoffice-repo.noarch.rpm
 RUN yum -y install onlyoffice-documentbuilder
-CMD /bin/bash -c "onlyoffice-documentbuilder; \
+CMD /bin/bash -c "onlyoffice-documentbuilder -v; \
                   cd /doc-builder-testing; \
                   bundle exec parallel_rspec spec"

--- a/dockerfiles/centos-7/Dockerfile
+++ b/dockerfiles/centos-7/Dockerfile
@@ -18,4 +18,4 @@ RUN yum -y install https://download.onlyoffice.com/repo/centos/main/noarch/onlyo
 RUN yum -y install onlyoffice-documentbuilder
 CMD /bin/bash -c "onlyoffice-documentbuilder -v; \
                   cd /doc-builder-testing; \
-                  bundle exec parallel_rspec spec"
+                  rake rspec_critical"

--- a/dockerfiles/debian-develop/Dockerfile
+++ b/dockerfiles/debian-develop/Dockerfile
@@ -20,6 +20,6 @@ RUN echo "deb [trusted=yes] https://s3.eu-west-1.amazonaws.com/repo-doc-onlyoffi
     apt-get -y install onlyoffice-documentbuilder
 RUN cat /etc/apt/sources.list.d/onlyoffice-dev.list
 
-CMD /bin/bash -c "onlyoffice-documentbuilder; \
+CMD /bin/bash -c "onlyoffice-documentbuilder -v; \
                   cd /doc-builder-testing; \
                   rake rspec_critical"

--- a/dockerfiles/debian-next-release/Dockerfile
+++ b/dockerfiles/debian-next-release/Dockerfile
@@ -20,6 +20,6 @@ RUN echo "deb [trusted=yes] https://s3.eu-west-1.amazonaws.com/repo-doc-onlyoffi
     apt-get -y install onlyoffice-documentbuilder=$VERSION-*
 RUN cat /etc/apt/sources.list.d/onlyoffice-dev.list
 
-CMD /bin/bash -c "onlyoffice-documentbuilder; \
+CMD /bin/bash -c "onlyoffice-documentbuilder -v; \
                   cd /doc-builder-testing; \
                   rake rspec_critical"


### PR DESCRIPTION
* Uses `actions/checkout@v3`
* Excluded duplicate builds of the base `Dockerfile`
* Running `critical` tests is now required for all versions except `debian-archive`
* Added output of the version of the installed `documentbuidler -v`