### PR TITLE
feature: docker-hub build via cron shedule

### DIFF
--- a/.github/workflows/docker-hub-push.yml
+++ b/.github/workflows/docker-hub-push.yml
@@ -1,8 +1,8 @@
 name: docker-hub-push
 on:
-  push:
-    branches:
-      - 'master'
+  schedule:
+    # UTC by Moscow 9 am
+    - cron: '0 6 * * *'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/docker-hub-push.yml
+++ b/.github/workflows/docker-hub-push.yml
@@ -2,7 +2,7 @@ name: docker-hub-push
 on:
   schedule:
     # UTC by Moscow 9 am
-    - cron: '0 6 * * *'
+    - cron: '0 5 * * *'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Judging by the [cron documentation](https://manpages.debian.org/unstable/cron/cron.8.en.html) the test build will run at 6 am by UTC

Unfortunately the dependabot schedule config is [not supported](https://github.com/orgs/community/discussions/13454) like this

```yml
    schedule:
      interval: daily
      time: "08:00"
      timezone: "Europe/Moscow"
```

Default UTC